### PR TITLE
upgrade mysql package to mysql2

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const async = require('async')
 const _ = require('lodash')
-const mysql = require('mysql')
+const mysql = require('mysql2')
 const Base = require('bfx-facs-base')
 const { promisify } = require('util')
 const { promiseFlat } = require('@bitfinex/lib-js-util-promise')

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "async": "^3.2.1",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
     "lodash": "^4.17.21",
-    "mysql": "^2.18.1"
+    "mysql2": "^3.9.2"
   },
   "engine": {
     "node": ">=8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-facs-db-mysql",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "private": false,
   "description": "Bitfinex DB MySQL Facility",
   "author": {

--- a/test/unit.js
+++ b/test/unit.js
@@ -464,7 +464,7 @@ describe('DbFacility tests', () => {
       await sleep(1000)
       calls = spy.getCalls().map(x => x.args)
       resultCalls = calls.filter(x => x[0] === 'result')
-      closeCalls = calls.filter(x => ['finish', 'close'].includes(x[0]))
+      closeCalls = calls.filter(x => x[0] === 'finish')
 
       spy.restore()
 

--- a/test/unit.js
+++ b/test/unit.js
@@ -464,7 +464,7 @@ describe('DbFacility tests', () => {
       await sleep(1000)
       calls = spy.getCalls().map(x => x.args)
       resultCalls = calls.filter(x => x[0] === 'result')
-      closeCalls = calls.filter(x => x[0] === 'close')
+      closeCalls = calls.filter(x => ['finish', 'close'].includes(x[0]))
 
       spy.restore()
 


### PR DESCRIPTION
Old [`mysql`](https://www.npmjs.com/package/mysql) package does not support the new `caching_sha2_password` authentication mechanism introduced in MySQL version 8. Also, the old `mysql` package was last updated 4 years ago so it's unlikely that it is still a maintained package.

This PR switches to [`mysql2`](https://www.npmjs.com/package/mysql2) package which is more popular now and thankfully mostly maintains backwards-compatibility with the older `mysql` package. The APIs are the same for the most part and I've only noticed some minor differences in the events that are emitted between the two. For instance, while the older package emits a `close` event, the newer package emits `finish`. Still, for the most part, the events emitted are the same across both but it's noteworthy to watch out for it in our existing codebases.