### PR TITLE
Revert "upgrade mysql package to mysql2"

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const async = require('async')
 const _ = require('lodash')
-const mysql = require('mysql2')
+const mysql = require('mysql')
 const Base = require('bfx-facs-base')
 const { promisify } = require('util')
 const { promiseFlat } = require('@bitfinex/lib-js-util-promise')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-facs-db-mysql",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "private": false,
   "description": "Bitfinex DB MySQL Facility",
   "author": {
@@ -22,7 +22,7 @@
     "async": "^3.2.1",
     "bfx-facs-base": "git+https://github.com/bitfinexcom/bfx-facs-base.git",
     "lodash": "^4.17.21",
-    "mysql2": "^3.9.2"
+    "mysql": "^2.18.1"
   },
   "engine": {
     "node": ">=8.0"

--- a/test/unit.js
+++ b/test/unit.js
@@ -464,7 +464,7 @@ describe('DbFacility tests', () => {
       await sleep(1000)
       calls = spy.getCalls().map(x => x.args)
       resultCalls = calls.filter(x => x[0] === 'result')
-      closeCalls = calls.filter(x => x[0] === 'finish')
+      closeCalls = calls.filter(x => x[0] === 'close')
 
       spy.restore()
 


### PR DESCRIPTION
Reverts bitfinexcom/bfx-facs-db-mysql#4, it seems that there are cases where results are not consistent between libraries not making them backwards compatible. 